### PR TITLE
feat(auth): add email verification flow with confirm and result pages

### DIFF
--- a/src/components/Button/Button.styled.ts
+++ b/src/components/Button/Button.styled.ts
@@ -120,7 +120,7 @@ export const StyledButton = styled(AntButton) <Omit<ButtonProps, 'title'>>`
   }
   
   /* Hover effect */
-  &:hover:not(:disabled) {
+  .ant-btn-variant-outlined&:hover:not(:disabled) {
     background: ${props => colorMap[props.color || 'primary'].hover};
     color: ${props => colorMap[props.color || 'primary'].text};
     transform: translateY(-1px);

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -15,7 +15,7 @@ interface NavbarElement {
 // Menu cho Customer
 const customerNavbar: NavbarElement[] = [
   { path: '/', label: 'Learn', icon: symbols.birdhouse },
-  { path: '/practice', label: 'Practice', icon: symbols.dumbbell },
+  // { path: '/practice', label: 'Practice', icon: symbols.dumbbell },
   { path: '/leaderboard', label: 'Leaderboard', icon: symbols.trophy },
   { path: '/quest', label: 'Quest', icon: symbols.parchment },
   { path: '/shop', label: 'Shop', icon: symbols.shop },

--- a/src/components/StatsBar/StatsBar.tsx
+++ b/src/components/StatsBar/StatsBar.tsx
@@ -29,6 +29,8 @@ import {
 } from './StatsBar.styled';
 import { theme } from '@/themes';
 import { useAuth } from '@/hooks';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 interface Course {
     id: string;
@@ -67,6 +69,7 @@ interface StatItemData {
 
 const StatsBar: React.FC = () => {
     const { profile } = useAuth();
+    const balance = useSelector((state: RootState) => state.user.balance);
     const [openDropdown, setOpenDropdown] = useState<string | null>(null);
     const [selectedCourse, setSelectedCourse] = useState<Course>({
         id: 'en',
@@ -136,7 +139,7 @@ const StatsBar: React.FC = () => {
         {
             id: 'diamond',
             icon: <HeartIcon>💎</HeartIcon>,
-            value: profile?.balance || 0,
+            value: balance || 0,
             color: '#1cb0f6',
             bgColor: '#e6f7ff',
             borderColor: '#1cb0f6',

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -4,6 +4,8 @@ const routes = {
     welcome: "/welcome",
     login: "/login",
     register: "/register",
+    verify: "/verify",
+    verifyResult: "/verify/result",
   },
   user: {
     exercise: "/exercise/:lessonId",

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -44,6 +44,7 @@ const useAuth = () => {
     const [profile, setProfile] = useState<UserType | null>(null);
     const [userID, setUserID] = useState<string | null>(getUserID());
     const [loading, setLoading] = useState(true);
+    const [loadingProfile, setLoadingProfile] = useState(false);
     const hasFetched = useRef(false);
 
     const accessToken = cookieUtils.getAccessToken();
@@ -60,6 +61,7 @@ const useAuth = () => {
     }, [accessToken]);
 
     const fetchProfile = async () => {
+        setLoadingProfile(true);
         try {
             const res = await getProfile();
             setProfile(res.data.data as UserType);
@@ -69,6 +71,8 @@ const useAuth = () => {
             dispatch(setFreezeCount(res.data.data.freeze_count));
         } catch (error) {
             console.log(error);
+        } finally {
+            setLoadingProfile(false);
         }
     }
 
@@ -95,7 +99,7 @@ const useAuth = () => {
         return () => clearInterval(interval);
     }, [checkTokenExpiration]);
 
-    return { loading, profile, userID };
+    return { loadingProfile, loading, profile, userID, fetchProfile };
 }
 
 export default useAuth;

--- a/src/pages/Auth/Register/Register.tsx
+++ b/src/pages/Auth/Register/Register.tsx
@@ -3,8 +3,7 @@ import AuthForm from "@/components/AuthForm";
 import { RedirectType } from "@/components/AuthForm/AuthForm";
 import { registerFields } from "@/components/AuthForm/AuthForm.fields";
 import config from "@/config";
-import { login, register } from "@/services/authAPI";
-import cookieUtils from "@/services/cookieUtils";
+import { register } from "@/services/authAPI";
 import { RootState } from "@/store";
 import { message } from "antd";
 import { useState } from "react";
@@ -33,18 +32,7 @@ const Register = () => {
                     content: response.data.message || "Register successfully",
                 });
                 localStorage.setItem('FIRST_STEP', 'true');
-                const loginResponse = await login({
-                    email: values.email,
-                    password: values.password,
-                });
-                if (!loginResponse.data.data) throw loginResponse.data.message;
-                else {
-                    cookieUtils.setItem(config.cookies.accessToken, loginResponse.data.data.accessToken);
-                    cookieUtils.setItem(config.cookies.refreshToken, loginResponse.data.data.refreshToken);
-                    cookieUtils.setItem(config.cookies.role, loginResponse.data.data.role);
-                }
-                if (loginResponse.data.data.role === 1) navigate(config.routes.admin.language)
-                else navigate(config.routes.public.home);
+                navigate(config.routes.public.verify);
             }
         } catch (error: any) {
             if (error.response) messageApi.error(error.response.data.message);

--- a/src/pages/Auth/Verify/VerifyConfirm/VerifyConfirm.styled.ts
+++ b/src/pages/Auth/Verify/VerifyConfirm/VerifyConfirm.styled.ts
@@ -1,0 +1,39 @@
+import styled, { keyframes } from "styled-components";
+
+const bounce = keyframes`
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-12px); }
+`;
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f7faff;
+  border-radius: 24px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  padding: 56px 32px;
+`;
+
+export const Mascot = styled.img`
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+  background: #fff;
+  animation: ${bounce} 1.5s infinite;
+`;
+
+export const Icon = styled.div`
+  margin-bottom: 24px;
+`;
+
+export const Message = styled.div`
+  font-size: 1.25rem;
+  color: #444;
+  text-align: center;
+  line-height: 1.7;
+`;

--- a/src/pages/Auth/Verify/VerifyConfirm/VerifyConfirm.tsx
+++ b/src/pages/Auth/Verify/VerifyConfirm/VerifyConfirm.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Container, Icon, Message, Mascot } from "./VerifyConfirm.styled";
+import { MailOutlined } from "@ant-design/icons";
+import catHi from "@/assets/cat-hi.png";
+
+const VerifyConfirm: React.FC = () => (
+  <Container>
+    <Mascot src={catHi} alt="Waving Cat Mascot" />
+    <Icon>
+      <MailOutlined style={{ fontSize: 64, color: "#1890ff" }} />
+    </Icon>
+    <Message>
+      <span role="img" aria-label="wave">👋</span> Yay! One last step...<br />
+      Please check your mailbox for a verification email.<br />
+      Click the link in the email to verify your account and join the Nekolingo family! <span role="img" aria-label="cat">🐾</span>
+    </Message>
+  </Container>
+);
+
+export default VerifyConfirm;

--- a/src/pages/Auth/Verify/VerifyConfirm/index.ts
+++ b/src/pages/Auth/Verify/VerifyConfirm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VerifyConfirm";

--- a/src/pages/Auth/Verify/VerifyResult/VerifyResult.styled.ts
+++ b/src/pages/Auth/Verify/VerifyResult/VerifyResult.styled.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+`;
+
+export const ResultBox = styled.div`
+  min-height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ReturnButtonWrapper = styled.div`
+  margin-top: 32px;
+`;

--- a/src/pages/Auth/Verify/VerifyResult/VerifyResult.tsx
+++ b/src/pages/Auth/Verify/VerifyResult/VerifyResult.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { verifyEmail } from "@/services/authAPI";
+import { Spin } from "antd";
+import { Container, ResultBox, ReturnButtonWrapper } from "./VerifyResult.styled";
+import Button from "@/components/Button";
+import config from "@/config";
+
+const VerifyResult = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const params = new URLSearchParams(location.search);
+    const token = params.get("token");
+    const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+    const [message, setMessage] = useState("");
+    const hasVerified = useRef(false);
+
+    const handleVerifyEmail = async () => {
+        try {
+            const response = await verifyEmail(token!);
+            if (response.status === 200) {
+                setStatus("success");
+                setMessage(response.data.message);
+            }
+        } catch (error: any) {
+            setStatus("error");
+            setMessage(error.response?.data?.message || "Verification failed.");
+        }
+    }
+
+    useEffect(() => {
+        if (!token) {
+            setStatus("error");
+            setMessage("Invalid or missing verification token.");
+            return;
+        }
+
+        if (!hasVerified.current) {
+            handleVerifyEmail();
+            hasVerified.current = true;
+        }
+
+    }, [location.search]);
+
+    const handleReturnLogin = () => {
+        navigate(config.routes.public.login);
+    };
+
+    return (
+        <Container>
+            <ResultBox>
+                {status === "loading" && <Spin />}
+                {status === "success" && (
+                    <>
+                        <div style={{ fontSize: 48, color: "#4caf50" }}>✔️</div>
+                        <div style={{ marginTop: 16, fontWeight: 500 }}>{message}</div>
+                    </>
+                )}
+                {status === "error" && (
+                    <>
+                        <div style={{ fontSize: 48, color: "#f44336" }}>❌</div>
+                        <div style={{ marginTop: 16, fontWeight: 500 }}>{message}</div>
+                    </>
+                )}
+                <ReturnButtonWrapper>
+                    <Button onClick={handleReturnLogin} size="medium" title={"Quay về đăng nhập"}/>
+                </ReturnButtonWrapper>
+            </ResultBox>
+        </Container>
+    );
+};
+
+export default VerifyResult;

--- a/src/pages/Auth/Verify/VerifyResult/index.ts
+++ b/src/pages/Auth/Verify/VerifyResult/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VerifyResult";

--- a/src/pages/Exercises/Type/CompleteSentences/CompleteSentences.tsx
+++ b/src/pages/Exercises/Type/CompleteSentences/CompleteSentences.tsx
@@ -18,7 +18,7 @@ import { ExerciseProgressState, setExercisesProgress } from "@/store/userProgres
 import { removeHeart } from "@/store/user.slice";
 import config from "@/config";
 import { QuestionCircleOutlined } from "@ant-design/icons";
-import { explainAnswer } from "@/services/userProgressAPI";
+import { explainAnswer, submitExercise, SubmitExerciseType } from "@/services/userProgressAPI";
 
 interface CompleteSentencesProps {
   data: any;
@@ -107,12 +107,21 @@ const CompleteSentences: React.FC<CompleteSentencesProps> = ({
     }
   };
 
-  const handleCheck = () => {
+  const handleCheck = async () => {
     setIsSubmitted(true);
     if (!selectedWords[0]) return;
     const correct = selectedWords[0].trim().toLowerCase() === correct_answer.trim().toLowerCase();
 
     setIsRunning(false);
+
+    const userExerciseSubmit: SubmitExerciseType = {
+      user_id: userId,
+      exercise_id: data._id,
+      user_answer: selectedWords[0],
+      answer_time: seconds,
+    }
+    await submitExercise(userExerciseSubmit);
+    
     if (correct) {
       const exercisesResult: ExerciseProgressState = {
         exercise_id: data._id ? data._id : "",
@@ -240,12 +249,12 @@ const CompleteSentences: React.FC<CompleteSentencesProps> = ({
           type="primary"
           onClick={getAIExplaiation}
         >
-          
-            {answerLoading? <Spin /> : (
-              <Flex vertical className="w-80 bg-white rounded p-4 mb-60 border" align="flex-end" >
-                {explainAI ? explainAI : 'Không có phản hồi'}
-              </Flex>
-            )}
+
+          {answerLoading ? <Spin /> : (
+            <Flex vertical className="w-80 bg-white rounded p-4 mb-60 border" align="flex-end" >
+              {explainAI ? explainAI : 'Không có phản hồi'}
+            </Flex>
+          )}
         </FloatButton.Group>
       )}
     </Wrapper>

--- a/src/pages/Exercises/Type/Listening/Listening.tsx
+++ b/src/pages/Exercises/Type/Listening/Listening.tsx
@@ -19,7 +19,7 @@ import { RootState } from "@/store";
 import { ExerciseProgressState, setExercisesProgress } from "@/store/userProgress.slice";
 import { removeHeart } from "@/store/user.slice";
 import config from "@/config";
-import { explainAnswer } from "@/services/userProgressAPI";
+import { explainAnswer, submitExercise, SubmitExerciseType } from "@/services/userProgressAPI";
 
 const { Title } = Typography;
 
@@ -76,12 +76,21 @@ const Listening: React.FC<ListeningProps> = ({ data, totalQuestions, answeredQue
         }
     };
 
-    const handleCheck = () => {
+    const handleCheck = async () => {
         setIsRunning(false);
         setIsSubmitted(true);
         if (selectedIndex === null) return;
         const selectedValue = options[selectedIndex];
         const correct = selectedValue.trim().toLowerCase() === correct_answer.trim().toLowerCase();
+
+        const userExerciseSubmit: SubmitExerciseType = {
+            user_id: userId,
+            exercise_id: data._id,
+            user_answer: selectedValue,
+            answer_time: seconds,
+        }
+        await submitExercise(userExerciseSubmit);
+
         if (correct) {
             const exercisesResult: ExerciseProgressState = {
                 exercise_id: data._id ? data._id : "",

--- a/src/pages/Exercises/Type/MatchPairs/MatchPairs.tsx
+++ b/src/pages/Exercises/Type/MatchPairs/MatchPairs.tsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '@/store';
 import { ExerciseProgressState, setExercisesProgress } from '@/store/userProgress.slice';
 import config from '@/config';
-import { explainAnswer } from '@/services/userProgressAPI';
+import { explainAnswer, submitExercise, SubmitExerciseType } from '@/services/userProgressAPI';
 import { Flex, FloatButton, Spin } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 
@@ -161,12 +161,20 @@ const MatchPairs: React.FC<MatchPairsProps> = ({
     };
 
     // Khi user "KIỂM TRA" (auto-called khi đủ 5 cặp)
-    const handleCheckBar = () => {
+    const handleCheckBar = async () => {
         // Vì nối đủ 5 cặp ⇒ đúng
         setIsRunning(false);
         setIsCorrectBar(true);
         setIsCheckedBar(true);
         setIsSubmitted(true);
+
+        const userExerciseSubmit: SubmitExerciseType = {
+            user_id: userId,
+            exercise_id: data._id,
+            user_answer: matchedPairs,
+            answer_time: seconds,
+        }
+        await submitExercise(userExerciseSubmit);
 
         if (matchedPairs) {
             const exercisesResult: ExerciseProgressState = {

--- a/src/pages/Exercises/Type/MultipleChoice/MultipleChoice.tsx
+++ b/src/pages/Exercises/Type/MultipleChoice/MultipleChoice.tsx
@@ -15,7 +15,7 @@ import { RootState } from "@/store";
 import { removeHeart } from "@/store/user.slice";
 import { useNavigate } from "react-router-dom";
 import config from "@/config";
-import { explainAnswer } from "@/services/userProgressAPI";
+import { explainAnswer, submitExercise, SubmitExerciseType } from "@/services/userProgressAPI";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface MultipleChoiceProps {
@@ -74,7 +74,7 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
     }
 
     // Handle selection and checking
-    const handleCheck = () => {
+    const handleCheck = async () => {
         setIsRunning(false);
         setIsSubmitted(true);
 
@@ -83,6 +83,14 @@ const MultipleChoice: React.FC<MultipleChoiceProps> = ({
 
         const correct = selectedOpt.toLowerCase() === correctAnswer?.toLowerCase();
 
+        const userExerciseSubmit: SubmitExerciseType = {
+            user_id: userId,
+            exercise_id: data._id,
+            user_answer: selectedOpt,
+            answer_time: seconds,
+        }
+        await submitExercise(userExerciseSubmit);
+        
         if (correct) {
             const exercisesResult: ExerciseProgressState = {
                 exercise_id: data._id ? data._id : "",

--- a/src/pages/Exercises/Type/SelectImage/SelectImage.tsx
+++ b/src/pages/Exercises/Type/SelectImage/SelectImage.tsx
@@ -15,7 +15,7 @@ import { ExerciseProgressState, setExercisesProgress } from "@/store/userProgres
 import { removeHeart } from "@/store/user.slice";
 import { useNavigate } from "react-router-dom";
 import config from "@/config";
-import { explainAnswer } from "@/services/userProgressAPI";
+import { explainAnswer, submitExercise, SubmitExerciseType } from "@/services/userProgressAPI";
 import { Flex, FloatButton, Spin } from "antd";
 import { QuestionCircleOutlined } from "@ant-design/icons";
 
@@ -67,13 +67,21 @@ const SelectImage: React.FC<SelectImageProps> = ({
     return () => clearInterval(interval);
   }, [isRunning]);
 
-  const handleCheck = () => {
+  const handleCheck = async () => {
     setIsRunning(false);
     setIsSubmitted(true);
     if (selectedIndex === null) return;
 
     const selectedOpt = options[selectedIndex];
     const correct = selectedOpt.value?.toLowerCase() === correctAnswer?.toLowerCase();
+
+    const userExerciseSubmit: SubmitExerciseType = {
+      user_id: userId,
+      exercise_id: data._id,
+      user_answer: selectedOpt.value,
+      answer_time: seconds,
+    }
+    await submitExercise(userExerciseSubmit);
 
     if (correct) {
       const exercisesResult: ExerciseProgressState = {

--- a/src/pages/Exercises/Type/SortSentence/SortSentence.tsx
+++ b/src/pages/Exercises/Type/SortSentence/SortSentence.tsx
@@ -9,7 +9,7 @@ import { RootState } from '@/store';
 import { ExerciseProgressState, setExercisesProgress } from '@/store/userProgress.slice';
 import { removeHeart } from '@/store/user.slice';
 import config from '@/config';
-import { explainAnswer } from '@/services/userProgressAPI';
+import { explainAnswer, submitExercise, SubmitExerciseType } from '@/services/userProgressAPI';
 import { Flex, FloatButton, Spin } from 'antd';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 
@@ -103,7 +103,7 @@ const SortSentence: React.FC<SortSentenceProps> = ({
         }
     };
 
-    const handleCheck = (): void => {
+    const handleCheck = async () => {
         // if (selectedWords.some(word => word === "")) return;
         if (selectedWords.includes('')) return;
         setIsSubmitted(true);
@@ -118,6 +118,14 @@ const SortSentence: React.FC<SortSentenceProps> = ({
         setIsRunning(false);
 
         const answer = selectedWords.join(' ');
+
+        const userExerciseSubmit: SubmitExerciseType = {
+            user_id: userId,
+            exercise_id: data._id,
+            user_answer: answer,
+            answer_time: seconds,
+        }
+        await submitExercise(userExerciseSubmit);
 
         if (correct) {
             const exercisesResult: ExerciseProgressState = {

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleFilled, CloseCircleFilled, EditFilled } from '@ant-design/icons';
+import { CheckCircleFilled, CloseCircleFilled } from '@ant-design/icons';
 import {
     BodyContent,
     LeftSection,
@@ -20,7 +20,6 @@ import {
     StatImg,
     StatValue,
     StatLabel,
-    EditButton,
     AddFriendsSection,
     AddFriendsTitle,
     Title,
@@ -140,13 +139,12 @@ const Profile = () => {
                                         <span>+</span>
                                     </div>
                                 </ProfileAvatar>
-                                <EditButton>
-                                    <EditFilled />
-                                </EditButton>
                                 <ProfileInfo>
                                     <ProfileName>{profile?.username || "User"}</ProfileName>
                                     <ProfileHandle>{profile?.username || "User"}</ProfileHandle>
-                                    <ProfileJoinDate>{profile ? profile.createdAt.toString() : ""}</ProfileJoinDate>
+                                    <ProfileJoinDate>
+                                        Đã tham gia vào {profile ? formatDateTime(new Date(profile.createdAt), dateFormat.vietnamFormat) : ""}
+                                    </ProfileJoinDate>
                                 </ProfileInfo>
 
                             </ProfileHeader>

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -1,6 +1,8 @@
 import config from "@/config";
 import Login from "@/pages/Auth/Login";
 import Register from "@/pages/Auth/Register";
+import VerifyConfirm from "@/pages/Auth/Verify/VerifyConfirm";
+import VerifyResult from "@/pages/Auth/Verify/VerifyResult";
 import { Outlet } from "react-router-dom"
 
 const AuthRouter = () => {
@@ -11,6 +13,8 @@ const authRoutes = {
     children: [
         { path: config.routes.public.login, element: <Login/>},
         { path: config.routes.public.register, element: <Register/>},
+        { path: config.routes.public.verify, element: <VerifyConfirm /> },
+        { path: config.routes.public.verifyResult, element: <VerifyResult /> }
     ]
 }
 

--- a/src/services/authAPI.ts
+++ b/src/services/authAPI.ts
@@ -11,3 +11,7 @@ export const register = (user: object) => {
 export const getProfile = () => {
     return get('/api/auth/profile');
 }
+
+export const verifyEmail = (token: string) => {
+    return get(`/api/auth/verify-email?token=${token}`);
+}

--- a/src/services/userProgressAPI.ts
+++ b/src/services/userProgressAPI.ts
@@ -1,7 +1,18 @@
 import { CompleteFullLessonState } from "@/store/userProgress.slice";
 import { post } from "./apiCaller";
 
-const apiUrl = '/api/user-progress'
+const apiUrl = '/api/user-progress';
+
+export type SubmitExerciseType = {
+    user_id: string;
+    exercise_id: string;
+    user_answer: any;
+    answer_time: number;
+}
+
+export const submitExercise = (request: SubmitExerciseType) => {
+    return post(`${apiUrl}/submit-exercise`, request);
+}
 
 export const completeFullLesson = (request: CompleteFullLessonState) => {
     return post(`${apiUrl}/complete-full-lesson`, request);

--- a/src/store/user.slice.ts
+++ b/src/store/user.slice.ts
@@ -1,4 +1,5 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { getProfile } from "@/services/authAPI";
 
 export type UserStateType = {
     user_id: string;
@@ -40,5 +41,22 @@ const userSlice = createSlice({
 });
 
 export const { setHearts, addHeart, removeHeart, setBalance, setFreezeCount, setUserIDStore } = userSlice.actions;
+
+// Async thunk to fetch profile
+export const fetchProfile = createAsyncThunk(
+    "user/fetchProfile",
+    async (_, { dispatch }) => {
+        const res = await getProfile();
+        const data = res.data.data;
+        console.log(data);
+        // Dispatch actions to update each field
+        dispatch(setUserIDStore(data.id));
+        dispatch(setHearts(data.hearts));
+        dispatch(setBalance(data.balance));
+        dispatch(setFreezeCount(data.freeze_count));
+        // Optionally return data if you want to use it in extraReducers
+        return data;
+    }
+);
 
 export default userSlice.reducer;


### PR DESCRIPTION
- Implement VerifyConfirm page to instruct users to check their email
- Create VerifyResult page to handle verification token and display status
- Add new routes for verification flow
- Extend authAPI with verifyEmail endpoint
- Modify register flow to redirect to verification page instead of auto-login
- Add styled components for both verification pages
- Update user slice to include profile fetching logic